### PR TITLE
Improve .ci/check-and-release

### DIFF
--- a/.ci/check-and-release
+++ b/.ci/check-and-release
@@ -39,7 +39,7 @@ for release in $kubernetes_releases; do
   fi
 
   # check if hyperkube release exists already
-  if [ "$(echo "$hyperkube_releases" | grep "$release" | wc -l)" == "1" ]; then
+  if [ "$(echo "$hyperkube_releases" | grep "$release" | wc -l)" != "0" ]; then
     # skipping release as tag or branch exists already
     continue
   fi


### PR DESCRIPTION
/kind bug

Currently `.ci/check-and-release` wrongly tries to build and release v1.19.1 (there is already such release):

```
$ .ci/check-and-release
Must build an image for Kubernetes release v1.19.1 ...
Must build an image for Kubernetes release v1.19.11 ...
Must build an image for Kubernetes release v1.20.7 ...
Must build an image for Kubernetes release v1.21.1 ...
```

The reason is the strict check in 

https://github.com/gardener/hyperkube/blob/9bb60a04d6a6b1ef2ce57f729f8878b4cbc9bd7a/.ci/check-and-release#L41_L45

For v1.19.1, the result is 2, not 1:

```
$ git  ls-remote --tags --heads git@github.com:gardener/hyperkube.git | grep v1.19.1
d73182c117970ecb49119b064189b520e705c941	refs/tags/v1.19.1
ac31f3a16c9eb45dfdb1fda568270b46f9cc9423	refs/tags/v1.19.10
```

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
