### PR TITLE
Create gh release

### DIFF
--- a/.ci/check-and-release
+++ b/.ci/check-and-release
@@ -18,6 +18,11 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+if ! which hub > /dev/null; then
+  echo "Can't find 'hub' tool in PATH, please install from https://github.com/github/hub"
+  exit 1
+fi
+
 # poor man's version comparison helper
 function version {
   printf "1%d%02d%02d\n" $(echo "$1" | sed 's/v//g' | sed -e 's/\./ /g')
@@ -61,6 +66,7 @@ if (( ${#to_build_versions[@]} )); then
     git commit -m "Release $release"
     git tag "$release"
     git push origin "$release"
+    hub release create -m $release -m "# [hyperkube]" -m "## Docker Images" -m "hyperkube: \`eu.gcr.io/gardener-project/hyperkube:$release\`" $release
     popd >/dev/null
 
     git checkout master

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-IMAGE_REPOSITORY   := eu.gcr.io/gardener-project/gardener/hyperkube
+IMAGE_REPOSITORY   := eu.gcr.io/gardener-project/hyperkube
 IMAGE_TAG          := $(shell cat KUBERNETES_VERSION)
 KUBERNETES_VERSION := $(shell cat KUBERNETES_VERSION)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR now creates also a github release when new image is build.
There is also a small fix in the default image registry in the Makefile.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
