### PR TITLE
fix: add execute permissions before copy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ COPY . .
 ARG KUBERNETES_VERSION
 
 RUN wget https://storage.googleapis.com/kubernetes-release/release/$KUBERNETES_VERSION/bin/linux/amd64/kubelet && \
-    wget https://storage.googleapis.com/kubernetes-release/release/$KUBERNETES_VERSION/bin/linux/amd64/kubectl
+    wget https://storage.googleapis.com/kubernetes-release/release/$KUBERNETES_VERSION/bin/linux/amd64/kubectl && \
+    chmod +x kubectl kubelet
 
 ### actual container
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds executable permissions before the copy.  When trying to run the container, it fails with permission denied.


