### PR TITLE
Add multi platform build for amd64 and arm64

### DIFF
--- a/.ci/check-and-release
+++ b/.ci/check-and-release
@@ -57,11 +57,9 @@ if (( ${#to_build_versions[@]} )); then
   for release in ${to_build_versions[@]}; do
     echo "Must build an image for Kubernetes release $release ..."
     git checkout -b "release-$release"
-
     pushd "$(dirname $0)/.." >/dev/null
-    docker build -t "eu.gcr.io/gardener-project/hyperkube:$release" --build-arg=KUBERNETES_VERSION="$release" .
-    docker push     "eu.gcr.io/gardener-project/hyperkube:$release"
     echo "$release" > KUBERNETES_VERSION
+    make docker-push
     git add KUBERNETES_VERSION
     git commit -m "Release $release"
     git tag "$release"

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,16 +6,23 @@ RUN echo "package main\nimport \"time\"\nfunc main() { time.Sleep(time.Hour) }" 
     GOOS=linux go build -o /sleep sleep.go
 
 ### binary downloader
+# Arch specific stages are required to set arg appropriately, see https://github.com/docker/buildx/issues/157#issuecomment-538048500
 
-FROM alpine:3.12 AS builder
+FROM alpine:3.12 AS builder-amd64
+ARG ARCH=amd64
+
+FROM alpine:3.12 AS builder-arm64
+ARG ARCH=arm64
+
+FROM builder-$TARGETARCH as builder
 
 WORKDIR /tmp/hyperkube
 COPY . .
 
 ARG KUBERNETES_VERSION
 
-RUN wget https://storage.googleapis.com/kubernetes-release/release/$KUBERNETES_VERSION/bin/linux/amd64/kubelet && \
-    wget https://storage.googleapis.com/kubernetes-release/release/$KUBERNETES_VERSION/bin/linux/amd64/kubectl && \
+RUN wget https://storage.googleapis.com/kubernetes-release/release/$KUBERNETES_VERSION/bin/linux/$ARCH/kubelet && \
+    wget https://storage.googleapis.com/kubernetes-release/release/$KUBERNETES_VERSION/bin/linux/$ARCH/kubectl && \
     chmod +x kubectl kubelet
 
 ### actual container

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ It will detect for which versions a new image must be built, build and push it, 
 
 Prerequisites:
 
+* You must use a version of Docker that supports [BuildKit](https://docs.docker.com/develop/develop-images/build_enhancements/).
+* You have to use a multi platform driver for Docker (e.g. by running `docker buildx create --use`).
 * You must be eligible to `git push` tags to this repository.
 * You must configure `gcloud` to authenticate with a valid GCP service account that allows pushing to the Gardener GCR.
   * `gcloud auth activate-service-account --key-file=<path-to-key-file>`


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for building multi-platform images, namely `amd64` and `arm64`.

**Special notes for your reviewer**:
/cc @rfranzke @timebertt 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
