### PR TITLE
update versions of golang and alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ### sleep go program that allows to instantiate a container to use `docker cp` for coping the binaries out of it
 
-FROM golang:1.15 AS golang
+FROM golang:1.19 AS golang
 
 RUN echo "package main\nimport \"time\"\nfunc main() { time.Sleep(time.Hour) }" > sleep.go && \
     GOOS=linux go build -o /sleep sleep.go
@@ -8,10 +8,10 @@ RUN echo "package main\nimport \"time\"\nfunc main() { time.Sleep(time.Hour) }" 
 ### binary downloader
 # Arch specific stages are required to set arg appropriately, see https://github.com/docker/buildx/issues/157#issuecomment-538048500
 
-FROM alpine:3.12 AS builder-amd64
+FROM alpine:3.16 AS builder-amd64
 ARG ARCH=amd64
 
-FROM alpine:3.12 AS builder-arm64
+FROM alpine:3.16 AS builder-arm64
 ARG ARCH=arm64
 
 FROM builder-$TARGETARCH as builder


### PR DESCRIPTION
**What this PR does / why we need it**:

Go has several CVEs related to the 1.15 version used for `sleep`

Vulnerabilities found for image eu.gcr.io/gardener-project/hyperkube:v1.24.4: total - 24, critical - 2, high - 19, medium - 3, low - 0

While most aren't vulnerable due to code being used for sleep, updating the versions greatly reduces the number. 

(after update)
Vulnerabilities found for image eu.gcr.io/gardener-project/hyperkube:v1.24.4: total - 0, critical - 0, high - 0, medium - 0, low - 0

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

None

