### PR TITLE
Update base images and enable dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: docker
+  directory: /
+  schedule:
+    interval: daily

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ### sleep go program that allows to instantiate a container to use `docker cp` for coping the binaries out of it
 
-FROM golang:1.19 AS golang
+FROM golang:1.21.6 AS golang
 
 RUN echo "package main\nimport \"time\"\nfunc main() { time.Sleep(time.Hour) }" > sleep.go && \
     GOOS=linux go build -o /sleep sleep.go
@@ -8,10 +8,10 @@ RUN echo "package main\nimport \"time\"\nfunc main() { time.Sleep(time.Hour) }" 
 ### binary downloader
 # Arch specific stages are required to set arg appropriately, see https://github.com/docker/buildx/issues/157#issuecomment-538048500
 
-FROM alpine:3.16 AS builder-amd64
+FROM alpine:3.19.0 AS builder-amd64
 ARG ARCH=amd64
 
-FROM alpine:3.16 AS builder-arm64
+FROM alpine:3.19.0 AS builder-arm64
 ARG ARCH=arm64
 
 FROM builder-$TARGETARCH as builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,10 @@ RUN echo "package main\nimport \"time\"\nfunc main() { time.Sleep(time.Hour) }" 
 ### binary downloader
 # Arch specific stages are required to set arg appropriately, see https://github.com/docker/buildx/issues/157#issuecomment-538048500
 
-FROM alpine:3.19.0 AS builder-amd64
+FROM alpine:3.19 AS builder-amd64
 ARG ARCH=amd64
 
-FROM alpine:3.19.0 AS builder-arm64
+FROM alpine:3.19 AS builder-arm64
 ARG ARCH=arm64
 
 FROM builder-$TARGETARCH as builder


### PR DESCRIPTION
**What this PR does / why we need it**:
Base images of `hyperkube` are quite outdated. 
This PR updates them to the most recent versions (Go 1.21.6 & alpine 3.19.0).
Additionally, it enables dependabot for base images to avoid the same situation in the future.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
