### PR TITLE
Set job timeout of 30m

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -7,6 +7,7 @@ hyperkube:
         build-and-publish-hyperkube:
           execute: build-on-ci
           privilege_mode: privileged
+          timeout: '30m'
       traits:
         cronjob:
           interval: '1h'


### PR DESCRIPTION
**What this PR does / why we need it**:
The build and publish job can get stuck for various reasons and then need manual intervention. Set a timeout so they are canceled and retried in the next cron interval. 30m is very arbitrarily chosen, successful jobs only take a few minutes (or seconds if there is nothing to do).

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```
NONE
```
