### PR TITLE
migrate cc-utils actions/workflows from @master to @v1

### DIFF
--- a/.github/workflows/build-and-publish-hyperkube-images.yaml
+++ b/.github/workflows/build-and-publish-hyperkube-images.yaml
@@ -11,11 +11,11 @@ jobs:
       id-token: write
 
     steps:
-      - uses: gardener/cc-utils/.github/actions/oci-auth@master
+      - uses: gardener/cc-utils/.github/actions/oci-auth@v1
         with:
           oci-image-reference: europe-docker.pkg.dev/gardener-project/releases/hyperkube
-      - uses: gardener/cc-utils/.github/actions/trusted-checkout@master
-      - uses: gardener/cc-utils/.github/actions/setup-git-identity@master
+      - uses: gardener/cc-utils/.github/actions/trusted-checkout@v1
+      - uses: gardener/cc-utils/.github/actions/setup-git-identity@v1
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3.7.0
       - name: Set up Docker Buildx


### PR DESCRIPTION
Switch references to [cc-utils](https://github.com/gardener/cc-utils)
actions and reusable workflows from `@master` to `@v1`.

## Motivation

`v1` is the intended stable branch for downstream users. All internal cross-references
are pinned by commit digest, ensuring a consistent, self-contained snapshot. Coverage
(e.g. pre-qualification) will increase over time.

`master` remains the development branch and continues to work, but is not intended for
downstream consumption.

See the [Reuse and Branching Model](https://gardener.github.io/cc-utils) for details.
